### PR TITLE
miniwebrtc: add aarch64 support

### DIFF
--- a/libs/miniwebrtc/typedefs.h
+++ b/libs/miniwebrtc/typedefs.h
@@ -76,6 +76,9 @@
 //#define WEBRTC_ARCH_ARMEL
 #define WEBRTC_ARCH_32_BITS
 #define WEBRTC_ARCH_LITTLE_ENDIAN
+#elif defined(__aarch64__)
+#define WEBRTC_ARCH_64_BITS
+#define WEBRTC_ARCH_LITTLE_ENDIAN
 #elif defined(__mips__)
 #define WEBRTC_ARCH_32_BITS
 #define WEBRTC_BIG_ENDIAN


### PR DESCRIPTION
miniwebrtc fails to compile on aarch64/arm64 because the architecture isn't known.

this change adds the required configuration for arm64.