### PR TITLE
Various Q931 correctness fixes

### DIFF
--- a/libs/ysig/q931.cpp
+++ b/libs/ysig/q931.cpp
@@ -1297,6 +1297,7 @@ SignallingEvent* ISDNQ931Call::processMsgSetup(ISDNQ931Message* msg)
     msg->params().setParam("callednumtype",m_data.m_calledType);
     msg->params().setParam("callednumplan",m_data.m_calledPlan);
     msg->params().setParam("overlapped",String::boolText(m_overlap));
+    msg->params().setParam("transfer-cap",m_data.m_transferCapability);
     return new SignallingEvent(SignallingEvent::NewCall,msg,this);
 }
 
@@ -1655,7 +1656,7 @@ bool ISDNQ931Call::sendSetup(SignallingMessage* sigMsg)
 	if (q931()->parserData().flag(ISDNQ931::ForceSendComplete))
 	    msg->appendSafe(new ISDNQ931IE(ISDNQ931IE::SendComplete));
 	// BearerCaps
-	m_data.m_transferCapability = "speech";
+	m_data.m_transferCapability = sigMsg->params().getValue(YSTRING("transfer-cap"), "speech");
 	m_data.m_transferMode = "circuit";
 	m_data.m_transferRate = "64kbit";
 	m_data.m_format = sigMsg->params().getValue(YSTRING("format"),q931()->format());

--- a/libs/ysig/q931.cpp
+++ b/libs/ysig/q931.cpp
@@ -1749,6 +1749,8 @@ bool ISDNQ931Call::sendSetupAck()
 		Q931_CALL_ID,this);
 	    return sendReleaseComplete("congestion");
 	}
+	if (q931()->network())
+	    m_data.m_channelMandatory = true;
 	m_data.processChannelID(msg,true,&q931()->parserData());
 	m_channelIDSent = true;
     }

--- a/libs/ysig/q931.cpp
+++ b/libs/ysig/q931.cpp
@@ -1741,7 +1741,7 @@ bool ISDNQ931Call::sendSetupAck()
     ISDNQ931Message* msg = new ISDNQ931Message(ISDNQ931Message::SetupAck,this);
     if (!m_channelIDSent) {
 	m_data.m_channelType = "B";
-	if (m_circuit)
+	if (m_data.m_bri && m_circuit)
 	    m_data.m_channelSelect = lookup(m_circuit->code(),Q931Parser::s_dict_channelIDSelect_BRI);
 	if (!m_data.m_channelSelect) {
 	    Debug(q931(),DebugNote,"Call(%u,%u). No voice channel available [%p]",

--- a/libs/ysig/q931.cpp
+++ b/libs/ysig/q931.cpp
@@ -1471,6 +1471,8 @@ bool ISDNQ931Call::sendAlerting(SignallingMessage* sigMsg)
 		return sendReleaseComplete("congestion");
 	    }
 	}
+	if (q931()->network())
+	    m_data.m_channelMandatory = true;
 	m_data.processChannelID(msg,true,&q931()->parserData());
 	m_channelIDSent = true;
     }
@@ -1491,6 +1493,8 @@ bool ISDNQ931Call::sendCallProceeding(SignallingMessage* sigMsg)
 	m_rspBearerCaps = false;
     }
     if (!m_channelIDSent) {
+	if (q931()->network())
+	    m_data.m_channelMandatory = true;
 	m_data.processChannelID(msg,true);
 	m_channelIDSent = true;
     }
@@ -1519,6 +1523,8 @@ bool ISDNQ931Call::sendConnect(SignallingMessage* sigMsg)
 	    m_data.m_channelByNumber = true;
 	    m_data.m_channelSelect = lookup(m_circuit->code(),Q931Parser::s_dict_channelIDSelect_BRI);
 	}
+	if (q931()->network())
+	    m_data.m_channelMandatory = true;
 	m_data.processChannelID(msg,true,&q931()->parserData());
 	m_channelIDSent = true;
     }

--- a/modules/server/ysigchan.cpp
+++ b/modules/server/ysigchan.cpp
@@ -1085,7 +1085,7 @@ SigChannel::SigChannel(SignallingEvent* event)
     // call.preroute message
     m_route = message("call.preroute",false,true);
     // Parameters to be copied to call.preroute
-    static String params = "caller,called,callername,format,formats,callernumtype,callernumplan,callerpres,callerscreening,callednumtype,callednumplan,inn,overlapped";
+    static String params = "caller,called,callername,format,formats,callernumtype,callernumplan,callerpres,callerscreening,callednumtype,callednumplan,inn,overlapped,transfer-cap";
     plugin.copySigMsgParams(*m_route,event,&params);
     if (m_route->getBoolValue("overlapped") && !m_route->getValue("called"))
 	m_route->setParam("called","off-hook");
@@ -1237,6 +1237,7 @@ bool SigChannel::startCall(Message& msg, SigTrunk* trunk)
     sigMsg->params().copyParam(msg,"callednumplan");
     sigMsg->params().copyParam(msg,"inn");
     sigMsg->params().copyParam(msg,"calledpointcode");
+    sigMsg->params().copyParam(msg,"transfer-cap");
     // Copy RTP parameters
     if (msg.getBoolValue("rtp_forward")) {
 	NamedList* tmp = new NamedList("rtp");


### PR DESCRIPTION
Sicne we started to use yate in the Osmocom OCTOI (Osmocom Community TDM over IP) network, we encountered a number of problems in the Q.931 implementation while interoperating with a variety of EuroISDN equipment.

This pull request fixes those Q.931 bugs.