### PR TITLE
IAX fixes

### DIFF
--- a/libs/yiax/frame.cpp
+++ b/libs/yiax/frame.cpp
@@ -224,6 +224,7 @@ const TokenDict IAXInfoElement::s_ieData[] = {
     {"CALLTOKEN",         CALLTOKEN},
     {"CAPABILITY2",       CAPABILITY2},
     {"FORMAT2",           FORMAT2},
+    {"CALLINGANI2",       CALLINGANI2},
     {0,0}
 };
 
@@ -455,6 +456,7 @@ bool IAXIEList::createFromFrame(const IAXFullFrame* frame, bool incoming)
 	    case IAXInfoElement::RR_PKTS:
 	    case IAXInfoElement::RR_DROPPED:
 	    case IAXInfoElement::RR_OOO:
+	    case IAXInfoElement::CALLINGANI2:
 		if (data[i] != 4) {
 		    i = 0xFFFF;
 		    break;
@@ -683,6 +685,7 @@ void IAXIEList::toString(String& dest, const char* indent)
 	    case IAXInfoElement::RR_DROPPED:
 	    case IAXInfoElement::RR_OOO:
 	    case IAXInfoElement::RR_DELAY:
+	    case IAXInfoElement::CALLINGANI2:
 		dest << (unsigned int)((static_cast<IAXInfoElementNumeric*>(ie))->data());
 		break;
 	    case IAXInfoElement::TRANSFERID:

--- a/libs/yiax/frame.cpp
+++ b/libs/yiax/frame.cpp
@@ -476,6 +476,7 @@ bool IAXIEList::createFromFrame(const IAXFullFrame* frame, bool incoming)
 	    case IAXInfoElement::CALLINGTNS:
 	    case IAXInfoElement::FIRMWAREVER:
 	    case IAXInfoElement::RR_DELAY:
+	    case IAXInfoElement::ENCRYPTION:
 		if (data[i] != 2) {
 		    i = 0xFFFF;
 		    break;
@@ -489,7 +490,6 @@ bool IAXIEList::createFromFrame(const IAXFullFrame* frame, bool incoming)
 	    case IAXInfoElement::CALLINGPRES:
 	    case IAXInfoElement::CALLINGTON:
 	    case IAXInfoElement::CAUSECODE:
-	    case IAXInfoElement::ENCRYPTION:
 		if (data[i] != 1) {
 		    i = 0xFFFF;
 		    break;
@@ -508,10 +508,12 @@ bool IAXIEList::createFromFrame(const IAXFullFrame* frame, bool incoming)
 		i += 1;
 		break;
 	    default:
-		Debug(DebugInfo,"IAX Frame(%u,%u) with unknown IE identifier %u [%p]",
+		Debug(DebugWarn,"IAX Frame(%u,%u) with unknown IE identifier %u [%p]",
 		    frame->type(),frame->subclass(),data[i-1],frame);
 		appendBinary((IAXInfoElement::Type)data[i-1],data+i+1,data[i]);
 		i += data[i] + 1;
+		// unknown IEs are skipped by asterisk for future compatibility
+		break;
 	}
 	if (i == 0xFFFF)
 	    break;
@@ -704,11 +706,11 @@ void IAXIEList::toString(String& dest, const char* indent)
 	    case IAXInfoElement::CALLINGTNS:		//TODO: print more data
 	    case IAXInfoElement::FIRMWAREVER:
 	    case IAXInfoElement::VERSION:
+	    case IAXInfoElement::ENCRYPTION:		//TODO: print more data
 		ie->toString(dest);
 		break;
 	    // 1 byte
 	    case IAXInfoElement::IAX_UNKNOWN:
-	    case IAXInfoElement::ENCRYPTION:		//TODO: print more data
 		ie->toString(dest);
 		break;
 	    case IAXInfoElement::CALLINGPRES:

--- a/libs/yiax/yateiax.h
+++ b/libs/yiax/yateiax.h
@@ -158,6 +158,7 @@ public:
         CALLTOKEN = 0x36,        // BIN
         CAPABILITY2 = 0x37,      // BIN		1 byte version + array
         FORMAT2 = 0x38,          // BIN		1 byte version + array
+        CALLINGANI2 = 0x39,      // DW
     };
 
     /**


### PR DESCRIPTION
Since we started to interoperate our yate installation with the world-wide community of analog phone collectors (C*NET / ckts.info), two IAX interoperability problems with their Asterisk boxes became apparrent. Let's fix them