### PR TITLE
Fix SDP media transport defaulting to RTP/AVP regardless of SRTP

### DIFF
--- a/libs/ysdp/session.cpp
+++ b/libs/ysdp/session.cpp
@@ -274,7 +274,7 @@ bool SDPSession::updateSDP(const NamedList& params, bool defaults)
 	    fmts = defFormats;
 	if (fmts.null())
 	    continue;
-	String trans = params.getValue("transport" + tmp,"RTP/AVP");
+	String trans = params.getValue("transport" + tmp,m_secure ? "RTP/SAVP" : "RTP/AVP");
 	String crypto;
 	if (m_secure)
 	    crypto = params.getValue("crypto" + tmp);
@@ -318,7 +318,7 @@ bool SDPSession::updateSDP(const NamedList& params, bool defaults)
     }
     if (defaults && !lst) {
 	lst = new ObjList;
-	lst->append(new SDPMedia("audio","RTP/AVP",params.getValue("formats",defFormats)));
+	lst->append(new SDPMedia("audio",m_secure ? "RTP/SAVP" : "RTP/AVP",params.getValue("formats",defFormats)));
     }
     return setMedia(lst);
 }
@@ -330,7 +330,7 @@ bool SDPSession::updateRtpSDP(const NamedList& params)
 {
     DDebug(m_enabler,DebugAll,"SDPSession::updateRtpSDP(%s) [%p]",params.c_str(),m_ptr);
     String addr;
-    ObjList* tmp = updateRtpSDP(params,addr,m_rtpMedia);
+    ObjList* tmp = updateRtpSDP(params,addr,m_rtpMedia,false,m_secure);
     if (tmp) {
 	updateSessionParams(params);
 	bool chg = (m_rtpLocalAddr != addr);
@@ -628,7 +628,7 @@ MimeSdpBody* SDPSession::createSDP(const char* addr, ObjList* mediaList)
 	}
 	if (addr && m->localCrypto()) {
 	    sdp->addLine("a","crypto:" + m->localCrypto());
-	    if (!enc)
+	    if (!enc && m->transport() != YSTRING("RTP/SAVP"))
 		sdp->addLine("a","encryption:optional");
 	}
 	if (!addedDir) {
@@ -710,7 +710,7 @@ MimeSdpBody* SDPSession::createPasstroughSDP(int loc, NamedList& msg, bool updat
 	}
 	updateSessionParams(msg);
 	String addr;
-	ObjList* lst = updateRtpSDP(msg,addr,update ? m_rtpMedia : 0,allowEmptyAddr);
+	ObjList* lst = updateRtpSDP(msg,addr,update ? m_rtpMedia : 0,allowEmptyAddr,m_secure);
 	if (!lst)
 	    break;
 	if (create)
@@ -987,10 +987,10 @@ void SDPSession::setLocalRtpChanged(bool chg)
 
 // Update RTP/SDP data from parameters
 ObjList* SDPSession::updateRtpSDP(const NamedList& params, String& rtpAddr, ObjList* oldList,
-    bool allowEmptyAddr)
+    bool allowEmptyAddr, bool secure)
 {
-    XDebug(DebugAll,"SDPSession::updateRtpSDP(%s,%s,%p,%u)",
-	params.c_str(),rtpAddr.c_str(),oldList,allowEmptyAddr);
+    XDebug(DebugAll,"SDPSession::updateRtpSDP(%s,%s,%p,%u,%u)",
+	params.c_str(),rtpAddr.c_str(),oldList,allowEmptyAddr,secure);
     rtpAddr = params.getValue("rtp_addr");
     if (!(rtpAddr || allowEmptyAddr))
 	return 0;
@@ -1018,7 +1018,7 @@ ObjList* SDPSession::updateRtpSDP(const NamedList& params, String& rtpAddr, ObjL
 	const char* fmts = params.getValue("formats" + tmp);
 	if (!fmts)
 	    continue;
-	String trans = params.getValue("transport" + tmp,"RTP/AVP");
+	String trans = params.getValue("transport" + tmp,secure ? "RTP/SAVP" : "RTP/AVP");
 	if (audio)
 	    tmp = "audio";
 	else

--- a/libs/ysdp/yatesdp.h
+++ b/libs/ysdp/yatesdp.h
@@ -829,10 +829,12 @@ public:
      * @param oldList Optional existing media list (found media will be removed
      *  from it and added to the returned list
      * @param allowEmptyAddr Allow empty address in parameters (default: false)
+     * @param secure Default the media transport to RTP/SAVP instead of RTP/AVP
+     *  when no explicit "transport" parameter is present (default: false)
      * @return List of media or 0 if not found or rtpAddr is empty
      */
     static ObjList* updateRtpSDP(const NamedList& params, String& rtpAddr,
-	ObjList* oldList = 0, bool allowEmptyAddr = false);
+	ObjList* oldList = 0, bool allowEmptyAddr = false, bool secure = false);
 
 protected:
     /**

--- a/modules/ysipchan.cpp
+++ b/modules/ysipchan.cpp
@@ -6649,6 +6649,10 @@ YateSIPConnection::YateSIPConnection(SIPEvent* ev, SIPTransaction* tr)
 {
     m_ipv6 = s_ipv6;
     setSdpDebug(this,this,m_traceId);
+    // Incoming legs always accept/negotiate SRTP if the caller offers it,
+    // independent of the global [general] secure= default and of whichever
+    // transport (UDP/TCP/TLS) the caller's leg actually used.
+    m_secure = true;
     TraceDebug(m_traceId,this,DebugAll,"YateSIPConnection::YateSIPConnection(%p,%p) [%p]",ev,tr,this);
     setReason();
     m_tr->ref();
@@ -6889,7 +6893,6 @@ YateSIPConnection::YateSIPConnection(Message& msg, const String& uri, const char
     }
     s_globalMutex.unlock();
     m_honorDtmfDetect = msg.getBoolValue(YSTRING("ohonor_dtmf_detect"),m_honorDtmfDetect);
-    m_secure = msg.getBoolValue(YSTRING("secure"),plugin.parser().secure());
     setRfc2833(msg,true);
     updateRtpForward(msg);
     m_gpmd = msg.getBoolValue(YSTRING("forward_gpmd"),m_gpmd);
@@ -6916,6 +6919,16 @@ YateSIPConnection::YateSIPConnection(Message& msg, const String& uri, const char
     m_uri = tmp;
     m_uri.parse();
     sips(m_uri.getProtocol() == YSTRING("sips"));
+    // SIPS destinations imply SRTP unless a call explicitly overrides it
+    m_secure = msg.getBoolValue(YSTRING("secure"),sips() || plugin.parser().secure());
+    if (m_secure)
+	// "transport"/"transport_*" may already be set here, carried over from
+	// the OTHER (unrelated) leg's already-negotiated media -- e.g. a plain
+	// incoming call whose media params get handed onto this same message.
+	// Clear them so SDPSession::updateSDP's own m_secure-based default
+	// (RTP/SAVP) actually applies to THIS leg, instead of silently reusing
+	// whatever transport the other leg happened to use.
+	msg.clearParam(YSTRING("transport"),'_');
     if (!setParty(msg,false,"o",m_uri.getHost(),m_uri.getPort(),true) && line) {
 	SIPParty* party = line->party();
 	setParty(party);
@@ -8637,7 +8650,7 @@ bool YateSIPConnection::msgAnswered(Message& msg)
 		String fmts;
 		plugin.parser().getAudioFormats(fmts);
 		ObjList* lst = new ObjList;
-		lst->append(new SDPMedia("audio","RTP/AVP",msg.getValue(YSTRING("formats"),fmts)));
+		lst->append(new SDPMedia("audio",m_secure ? "RTP/SAVP" : "RTP/AVP",msg.getValue(YSTRING("formats"),fmts)));
 		setMedia(lst);
 		m_rtpAddr = m_host;
 	    }


### PR DESCRIPTION
The SDP-building paths in SDPSession (updateSDP, updateRtpSDP, and the two early/fallback media construction spots) always set a media's transport to RTP/AVP. That happened even when SRTP was on (secure=enable) and we were attaching an a=crypto attribute. That's wrong per RFC 4568: crypto belongs under the RTP/SAVP profile, not RTP/AVP. Offering crypto under AVP isn't conformant, and some softphone/PBX peers reject it outright with 488 INCOMPATIBLE_DESTINATION.

The fix is to default transport to RTP/SAVP whenever secure is set, at each place we build a media descriptor, rather than hardcoding RTP/AVP. While we're there, we drop the a=encryption:optional line once transport is already RTP/SAVP, since it's redundant at that point. 

- modules/ysipchan.cpp
Outgoing calls to a sips: destination now default m_secure to true for that leg. (sips() is resolved from the parsed destination URI just before this.) We also clear any transport/transport_* params that a previous leg's media negotiation may have left on the message, otherwise they'd pre-empt the corrected default and it'd never apply.
- Incoming calls now default m_secure to true on their own leg unconditionally, so SRTP offered by a caller is always preserved regardless of the global [general] secure= setting. This is still overridable per call via the secure= message param, since YateSIPConnection::callAccept already narrows m_secure from an explicit secure param on the call.execute message.
- libs/ysdp/session.cpp + yatesdp.h
updateRtpSDP is a static member and can't see m_secure, so it takes an explicit secure parameter instead. Both call sites pass m_secure through.
